### PR TITLE
Potential fix for #7

### DIFF
--- a/utils/conversion_functions.py
+++ b/utils/conversion_functions.py
@@ -113,7 +113,7 @@ def normalize_replace_rules(rules):
         target = unicodedata.normalize("NFD", target)
         repl = unicodedata.normalize("NFD", repl)
         target = re.sub(r"([aeiou])", r"\1(́)?", target) # a -> a(́)?
-        target += r"(?=\w|\s|[!\"#\$%&'\(\)\*+,-\./:;<=>\?@\[\\\]\^_`\{\|\}~]|$)"
+        target += r"(?=\w|\s|[!\"#\$%&'\(\)\*+,-\./:;<=>\?@\[\\\]\^_`\{\|\}~’]|$)"
         repl = re.sub(r"([aeiou])", r"\1\\1", repl) # a -> a\1
         normalized_rules.append((rule_type, target, repl))
         normalized_rules.append((rule_type, target.upper(), repl.upper()))

--- a/utils/conversion_functions.py
+++ b/utils/conversion_functions.py
@@ -113,6 +113,10 @@ def normalize_replace_rules(rules):
         target = unicodedata.normalize("NFD", target)
         repl = unicodedata.normalize("NFD", repl)
         target = re.sub(r"([aeiou])", r"\1(́)?", target) # a -> a(́)?
+        # Following line implements 4. from above with a look-ahead
+        # assertion by requiring the next character to be either a
+        # letter, whitespace, one of a number of non-combining
+        # punctuation marks, or the end of the string.
         target += r"(?=\w|\s|[!\"#\$%&'\(\)\*+,-\./:;<=>\?@\[\\\]\^_`\{\|\}~’]|$)"
         repl = re.sub(r"([aeiou])", r"\1\\1", repl) # a -> a\1
         normalized_rules.append((rule_type, target, repl))


### PR DESCRIPTION
Add some more eye of newt to the mystical regex.

Would hopefully fix https://github.com/MCGallaspy/dakota_ortho_conversion/issues/7.

As for the rationale, please consider the docstring for the function:

```
    """ From a given Replace rule, derives rules with the following modifications:
        1. A version of the rule with all lower case letters.
        2. A version of the rule with the initial letter only uppercase.
        3. All vowels match their accented and unaccented versions,
            e.g. "a" matches "a" and "á".
        4. Prevent patterns from matching only part of a sequence of
           combining diacritics (in other words, h shouldn't match ȟ even
           though the former is a prefix of the latter because it would
           leave an orphaned combining diacritic character)
```

The changed line adds a [look-ahead assertion](https://docs.python.org/3/library/re.html) to target patterns that implements `4. Prevent patterns from matching only part of a sequence of combining diacritics...`. It does this by requiring the next character to be either a letter, whitespace, one of a number of non-combining punctuation marks, or the end of the string. However, this failed for the case mentioned in #7 because `’` ([Right Single Quotation Mark](https://unicodeplus.com/U+2019)) was not included in the possible punctuation marks. This change adds `’` to the possible punctuation marks.